### PR TITLE
Add banner, remove unnecessary title

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,6 +4,7 @@
 {% assign blog='#{enketo-blog}' %}
 {% assign api='#{enketo-api}' %}
 <header class="header">
+   <div class="header__banner">Enketo has joined ODK! <a href="https://blog.enketo.org/enketo-has-joined-odk">Learn more</a>.</div>
    <div class="content-ui">
       <a class="header__branding" href="{{ sites['enketo-main'] }}/">
          <img src="{{ sites['enketo-main']}}/media/images/logos/enketo_bare_white_150x56.png" alt="Enketo Logo"/>

--- a/_posts/2023-05-14-enketo-joins-odk.md
+++ b/_posts/2023-05-14-enketo-joins-odk.md
@@ -9,8 +9,6 @@ tags:
   - enketo
 ---
 
-### Enketo has joined ODK!
-
 I started Enketo in 2009 as a web-based alternative to [ODK Collect](https://docs.getodk.org/collect-intro), the popular Android app for offline data collection. Over time, Enketo has grown into a core component of great products like [Ona](https://ona.io), [KoboToolbox](https://ona.io), [OpenClinica](https://openclinica.com), [Survey123](https://survey123.arcgis.com), and of course, [ODK](https://getodk.org).
 
 Though I have had a great time developing Enketo and collaborating with so many impressive people, the past few years I have become increasingly interested in working on other things (such as woodworking). In August 2021, the ODK team agreed to take over leadership of the Enketo project. My own involvement in the greater Enketo project has reduced to just a few hours a week, and that work is mostly on custom features for a client.

--- a/css/screen.css
+++ b/css/screen.css
@@ -46,6 +46,15 @@ ul.posts span {
     display: block;
 }
 
+.header__banner {
+    width: 100%;
+    background: #fffde7;
+    text-align: center;
+    min-height: 30px;
+    padding: 7px;
+    font-weight: bold;
+}
+
 /*****************************************************************************/
 /*
 /* Posts


### PR DESCRIPTION
It bothered me that the header would disappear on the blog.

Also, people navigate directly to pages like https://blog.enketo.org/install-enketo-production-ubuntu/ and it'd be good for them to know. 

**Desktop**
<img width="1241" alt="Screenshot 2023-05-23 at 11 04 57" src="https://github.com/enketo/blog/assets/32369/2df59e2b-e66f-4b7a-a7e3-3c24ffb2810f">

**Mobile**
<img width="498" alt="Screenshot 2023-05-23 at 11 04 34" src="https://github.com/enketo/blog/assets/32369/677b4502-69c3-4650-906a-249bbb7509a7">
