### PR TITLE
fix(posts): update Likert post links DEV-651

### DIFF
--- a/_posts/2014-01-09-likert-widget.md
+++ b/_posts/2014-01-09-likert-widget.md
@@ -13,11 +13,11 @@ Enketo Smart Paper now includes a __Likert widget__ to enable the use of [Likert
 
 ![Likert Widget](../files/2014/01/likert.png "Likert Widget")
 
-To use a Likert widget just add appearance _"likert"_ to any _"select-one"_ question. See this [demo webform](https://enke.to/likert) and this [form source](https://docs.google.com/spreadsheet/ccc?key=0Al3Mw5sknZoPdEpCZ2NtLVdXeC1UeGg2LTctRW9wX3c&usp=sharing) to learn more.
+To use a Likert widget just add appearance _"likert"_ to any _"select-one"_ question. Search for `likert` and `agree5` in the [demo webform](https://ee.kobotoolbox.org/x/8JGrcU96) and [form source](https://docs.google.com/spreadsheets/d/1KLQiQyQ5BlN_wd-83p8Eb6xIU-TZp-yvzgrm20HecRI/htmlview#) to learn more.
 
 To facilitate the easy calculation of a Likert scale (by adding up the values of Likert items), you'll probably want to make sure you use _numeric values_ in those choice lists. You can perform the calculation either in the form itself (as done in the demo) or in your analysis.
 
-This brand new feature was sponsored by [WHO](http://who.int) through Ona.  
+This brand new feature was sponsored by [WHO](http://who.int) through Ona.
 
 Happy Likert scaling!
 


### PR DESCRIPTION
### 📣 Summary

Update in Likert post dead links to all widgets example.

### 👀 Preview steps

See http://localhost:3000/likert-widget/, note that new links work and updated instruction accordingly.

![image](https://github.com/user-attachments/assets/e2d5a01b-b139-44e4-8f27-4d1fc83a467a)
